### PR TITLE
Ping deb.sipwise.com instead of default GW

### DIFF
--- a/templates/scripts/includes/check-for-network
+++ b/templates/scripts/includes/check-for-network
@@ -13,10 +13,7 @@ einfon "Checking network status... "
 STATUS="Offline"
 EXIT_CODE=1
 
-GW="$(route -n | awk '/^0\.0\.0\.0/{print $2}')"
-GWDEV="$(route -n | awk '/^0\.0\.0\.0/{print $NF}')"
-
-if ping -c 3 "${GW}" >/dev/null ; then
+if ping -c 3 deb.sipwise.com >/dev/null ; then
   STATUS="Online (${GWDEV})"
   EXIT_CODE=0
 fi


### PR DESCRIPTION
I ran into a situation where the default GW didn't respond to pings and thus couldn't get past the network connectivity check. By pinging deb.sipwise.com this ensures DNS is working as well. So long as deb.sipwise.com continues to respond to pings this should be okay.